### PR TITLE
Line 98 had back ticks instead of quotation marks

### DIFF
--- a/code/Rubygems.php
+++ b/code/Rubygems.php
@@ -95,7 +95,7 @@ class Rubygems extends Object {
 	public static function require_gem($gem, $version = null, $tryupdating = false) {
 		// Check that ruby exists
 		if (self::$ruby_ok === null) {
-			self::$ruby_ok = (bool)`which ruby`;
+			self::$ruby_ok = (bool)'which ruby';
 		}
 		
 		if (!self::$ruby_ok) {


### PR DESCRIPTION
Line 98 had back ticks instead of quotation marks making the script report that ruby was not in the webserver\'s path when it was
