### PR TITLE
Line 116 gem version check fixed

### DIFF
--- a/code/Rubygems.php
+++ b/code/Rubygems.php
@@ -114,7 +114,7 @@ class Rubygems extends Object {
 			
 			$vers = explode('.', $ver);
 			
-			self::$gem_version_ok = ($vers[0] >= 1 && $vers[1] >= 2);
+			self::$gem_version_ok = (($vers[0] >= 1 && $vers[1] >= 2) OR ($vers[0] >= 2));
 		}
 
 		if (!self::$gem_version_ok) {


### PR DESCRIPTION
gem version fails for versions 2.0.0 and up and reports it as too low a version. This fixes this.
